### PR TITLE
Add mod name to the intro message

### DIFF
--- a/locale/ja/misc.cfg
+++ b/locale/ja/misc.cfg
@@ -1,4 +1,4 @@
-cube-msg-intro=へようこそ。最初の仕事はキューブをつかむことです。
+cube-msg-intro=Ultracube: Age of Cubeへようこそ。最初の仕事はキューブをつかむことです。
 cube-msg-project-completed=極秘建築計画が完了しました。
 
 [autoplace-control-names]


### PR DESCRIPTION
I also think the intro message should be formatted using `__1__` placeholder [here](https://github.com/grandseiken/factorio-ultracube/blob/59b3bd6cf5a4b75007c21b2cfbd53cb4fd8bcf78/control.lua#L82).
