### PR TITLE
Fix Better Victory screen statistics

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,8 @@ Date: 07. 01. 2024
     - Added optional compatibility with Stack Combinator.
   Modding:
     - Marked the Burner Fuel Bonus mod as incompatible.
+  Bugfixes:
+    - Fixed Better Victory Screen statistics using production instead of consumption values (#14).
 ---------------------------------------------------------------------------------------------------
 Version: 0.3.0
 Date: 07. 01. 2024

--- a/control.lua
+++ b/control.lua
@@ -306,14 +306,14 @@ local function better_victory_screen_statistics()
 
   local distance_travelled_by_cube = victory_statistics.distance_travelled_by_cube
   local production = force.item_production_statistics
-  local cubes_consumed = production.get_input_count("cube-ultradense-utility-cube")
-  local cubes_consumed_dormant = production.get_input_count("cube-dormant-utility-cube")
-  local cubes_consumed_phantom = production.get_input_count("cube-phantom-ultradense-constituent")
-  local cubes_consumed_phantom_dormant = production.get_input_count("cube-dormant-phantom-constituent")
-  local cubes_reconstructed = production.get_input_count("cube-legendary-iron-gear")
+  local cubes_consumed = production.get_output_count("cube-ultradense-utility-cube")
+  local cubes_consumed_dormant = production.get_output_count("cube-dormant-utility-cube")
+  local cubes_consumed_phantom = production.get_output_count("cube-phantom-ultradense-constituent")
+  local cubes_consumed_phantom_dormant = production.get_output_count("cube-dormant-phantom-constituent")
+  local cubes_reconstructed = production.get_output_count("cube-legendary-iron-gear")
   local cubes_consumed_total = cubes_consumed + cubes_consumed_dormant +
       cubes_consumed_phantom + cubes_consumed_phantom_dormant
-  local matter_created = production.get_output_count("cube-basic-matter-unit")
+  local matter_created = production.get_input_count("cube-basic-matter-unit")
 
   stats["ultracube"] = {order = "a", stats = {
     ["cube-distance-travelled"]        = {order = "a", value = distance_travelled_by_cube, unit = "distance"},


### PR DESCRIPTION
Fix that the Better Victory Screen statistics wasn't being shown correctly because it was showing production values instead of consumption values, as reported by Ruea. As Wiwiweb mentioned the production values are wrong when the ingredient is a catalyst, which is most cases with the cubes, so we need to use the consumption values. And as mentioned [here](https://lua-api.factorio.com/latest/classes/LuaFlowStatistics.html) the consumption values are the `output` values.

---

As shown by Ruea:
![image](https://github.com/grandseiken/factorio-ultracube/assets/39875036/4d87a09e-1512-4aa9-8540-438880882716)

---

After the fix and a very small test save:
![image](https://github.com/grandseiken/factorio-ultracube/assets/39875036/3afa9c34-f5ae-4585-94e1-f252f901b006)
![image](https://github.com/grandseiken/factorio-ultracube/assets/39875036/de721c49-e216-49ed-9648-6f0393fa4758)
