### PR TITLE
Add compatibility for Compact Circuits

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -3,6 +3,7 @@ require("prototypes.lib.mystery")
 
 require("updates.compatibility.aai_signal_transmission")
 require("updates.compatibility.circuit_hud")
+require("updates.compatibility.compact_circuits")
 require("updates.compatibility.cybersyn")
 require("updates.compatibility.display_plates")
 require("updates.compatibility.flow_control")

--- a/updates/compatibility/compact_circuits.lua
+++ b/updates/compatibility/compact_circuits.lua
@@ -1,0 +1,30 @@
+if mods["compaktcircuit"] then
+    local tech = data.raw.technology["compaktcircuit-tech"]
+    tech.prerequisites = {
+        "cube-combinatorics",
+        "cube-spectral-processor"
+    }
+    tech.unit = tech_cost_unit("2", 100)
+
+    local procname = "compaktcircuit-processor"
+    local proc = data.raw.recipe[procname]
+    proc.category = "cube-fabricator-handcraft"
+    proc.ingredients = {
+        { 'cube-electronic-circuit', 20 },
+        { 'cube-advanced-circuit', 30 },
+        { 'cube-spectral-processor', 10 }
+    }
+
+    data.raw.item[procname].order = "cube-" .. data.raw.item[procname].order
+
+    local proc_1x1 = data.raw.recipe[procname .. "_1x1"]
+    proc_1x1.category = "cube-fabricator-handcraft"
+    proc_1x1.ingredients = {
+        { 'cube-electronic-circuit', 10 },
+        { 'cube-advanced-circuit', 10 },
+        { 'cube-spectral-processor', 3 }
+    }
+
+    data.raw.item[procname .. "_1x1"].order = "cube-" .. data.raw.item[procname .. "_1x1"].order
+end
+


### PR DESCRIPTION
As mentioned on Discord, here's what I did for compatibility with Compact Circuits. It's pretty much just a straightforward replacement of non-Cube stuff with Cube stuff. Given how useful Compact Circuits is just for _documenting_ how combinator contraptions work, I was tempted to make them a little cheaper, but ultimately decided not to.