### PR TITLE
Update milestones preset with cube consumption

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -16,7 +16,7 @@ local linked_entities = require("__Ultracube__/scripts/linked_entities")
 local tech_unlock = require("__Ultracube__/scripts/tech_unlock")
 local teleport = require("__Ultracube__/scripts/teleport")
 local transition = require("__Ultracube__/scripts/transition")
-require("__Ultracube__/scripts/milestones")
+local milestones = require("__Ultracube__/scripts/milestones")
 
 local function create_initial_cube(player)
   local surface = player.surface
@@ -366,5 +366,6 @@ end
 remote.add_interface("Ultracube", {
   ["hint_entity"] = remote_hint_entity,
   ["better-victory-screen-statistics"] = better_victory_screen_statistics,
+  ["milestones_presets"] = milestones
 })
 

--- a/info.json
+++ b/info.json
@@ -22,6 +22,7 @@
     "?stack-combinator",
     "?aai-signal-transmission",
     "?better-victory-screen >= 0.2.7",
+    "?Milestones >= 1.3.22",
     "!Krastorio2",
     "!burner-fuel-bonus",
     "!factory-levels",

--- a/scripts/milestones.lua
+++ b/scripts/milestones.lua
@@ -13,11 +13,10 @@ local milestones = {
   {type = "item",  name = "cube-synthetic-premonition-card",     quantity = 1000, next = "x10"},
   {type = "item",  name = "cube-complete-annihilation-card",     quantity = 1000, next = "x10"},
 
-  -- TODO: re-enable cube usage stats by consumption once supported in milestones mod.
-  -- {type = "group", name = "The Cube"},
-  -- {type = "item",  name = "cube-ultradense-utility-cube",        quantity = 100, next = "x10"},
-  -- {type = "item",  name = "cube-phantom-ultradense-constituent", quantity = 1,   next = "x10", hidden = true},
-  -- {type = "item",  name = "cube-legendary-iron-gear",            quantity = 1,   next = "x10", hidden = true},
+  {type = "group", name = "The Cube"},
+  {type = "item_consumption",  name = "cube-ultradense-utility-cube",        quantity = 100, next = "x10"},
+  {type = "item_consumption",  name = "cube-phantom-ultradense-constituent", quantity = 1,   next = "x10", hidden = true},
+  {type = "item_consumption",  name = "cube-legendary-iron-gear",            quantity = 1,   next = "x10", hidden = true},
 
   {type = "group", name = "Components"},
   {type = "item",  name = "cube-electronic-circuit", quantity = 1},
@@ -65,16 +64,16 @@ local milestones = {
   {type = "item",  name = "cube-antimatter-reactor", quantity = 1},
 
   {type = "group", name = "Kills"},
-  {type = "kill",  name = "character", quantity = 1, next = "x5"},
+  {type = "kill",  name = "character", quantity = 1, next = "x5", hidden = true},
 }
 
-remote.add_interface("ultracube", {
-  milestones_presets = function()
-    return {
-      ["Ultracube: Age of Cube"] = {
-        required_mods = {"Ultracube"},
-        milestones = milestones,
-      },
-    }
-  end
-})
+local function milestones_preset()
+  return {
+    ["Ultracube: Age of Cube"] = {
+      required_mods = {"Ultracube"},
+      milestones = milestones,
+    },
+  }
+end
+
+return milestones_preset


### PR DESCRIPTION
I added "hidden" to character kills too, I think it's a fun easter egg that way (I did this for every mod).

I added a version requirement for Milestones otherwise older versions of Milestones would show this message:
![image](https://github.com/grandseiken/factorio-ultracube/assets/4723472/9b2e52d8-fbdf-4dae-91a9-75d273574a42)

Be aware, because of the optional version dependency, if someone updates Ultracube but not Milestones then Factorio will stop Ultracube from loading, and it doesn't make it obvious to players why. You might see some players asking for support about this for a little while.