### PR TITLE
BVS now needs to know which stats have tooltips

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -380,7 +380,7 @@ local function better_victory_screen_statistics()
 
   stats["ultracube"] = {order = "a", stats = {
     ["cube-distance-travelled"]        = {order = "a", value = distance_travelled_by_cube, unit = "distance"},
-    ["cube-utilisation"]               = {order = "b", value = cube_utilisation, unit = "percentage"},
+    ["cube-utilisation"]               = {order = "b", value = cube_utilisation, unit = "percentage", has_tooltip=true},
     ["cubes-consumed"]                 = {order = "c", value = cubes_consumed},
     ["cubes-consumed-dormant"]         = {order = "d", value = cubes_consumed_dormant},
     ["cubes-consumed-phantom"]         = {order = "e", value = cubes_consumed_phantom},


### PR DESCRIPTION
There was a slight update to the Better Victory Screen interface. Only problem until you add this change is that the tooltip won't show for the `Cube Utilization` entry. Also didn't add a changelog entry because I don't know if you believe this change is big enough to warrent it. Up to you :)

Technically I could bump the dependency version but older versions of BVS will still work just fine since this new property will be ignored. 

![image](https://github.com/grandseiken/factorio-ultracube/assets/39875036/96ea5c90-2c40-4342-b2e0-0f470c3574df)
