### PR TITLE
Fix copied prototypes missing icons field

### DIFF
--- a/prototypes/recipes_fluids.lua
+++ b/prototypes/recipes_fluids.lua
@@ -440,6 +440,7 @@ for _, fluid in ipairs(voidable_fluids) do
     icon = prototype.icon,
     icon_size = prototype.icon_size,
     icon_mipmaps = prototype.icon_mipmaps,
+    icons = prototype.icons,
     ingredients = {{type = "fluid", name = fluid, amount = 100}},
     results = {},
     energy_required = 4,

--- a/updates/ultralocomotion.lua
+++ b/updates/ultralocomotion.lua
@@ -10,6 +10,7 @@ for _, name in ipairs(fuel_items) do
       icon = base.icon,
       icon_size = base.icon_size,
       icon_mipmaps = base.icon_mipmaps,
+      icons = base.icons,
       fuel_category = base.fuel_category,
       fuel_value = base.fuel_value,
       fuel_acceleration_multiplier = (base.fuel_acceleration_multiplier or 1) * cube_item.fuel_acceleration_multiplier,


### PR DESCRIPTION
When launching with a mod that modifies some prototype's icons, if the mod modifies the prototype to use the `icons` field instead of `icon`, Ultracube will cause a crash.

Log here: [factorio-current.log](https://github.com/grandseiken/factorio-ultracube/files/15211215/factorio-current.log)

This happens with my accessibility mod that adds an overlay to coal.

The simple fix is in every spot that a prototype is created as a copy of another, also copy the `icons` field. I think I found them all.