### PR TITLE
Renai Transportation v1.3.0 Support

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -14,6 +14,7 @@ local entity_cache = require("__Ultracube__/scripts/entity_cache")
 local entity_combine = require("__Ultracube__/scripts/entity_combine")
 local linked_entities = require("__Ultracube__/scripts/linked_entities")
 local milestones = require("__Ultracube__/scripts/milestones")
+local mod_config_changed = require("__Ultracube__/updates/mod_config_changed_handling")
 local remote_ownership = require("__Ultracube__/scripts/remote_ownership")
 local tech_unlock = require("__Ultracube__/scripts/tech_unlock")
 local teleport = require("__Ultracube__/scripts/teleport")
@@ -151,7 +152,12 @@ end
 
 script.on_load(on_load)
 script.on_init(on_init)
-script.on_configuration_changed(on_init)
+script.on_configuration_changed(
+	function(ConfigurationChangedData)
+		mod_config_changed.run_handlers(ConfigurationChangedData)
+		on_init()
+	end
+)
 
 commands.add_command(
   "cube_refresh", nil,

--- a/updates/compatibility/renai_transportation.lua
+++ b/updates/compatibility/renai_transportation.lua
@@ -63,6 +63,7 @@ if mods["RenaiTransportation"] then
     "PlayerLauncherRecipie", -- se~no
     "HatchRTRecipe", -- HatchRTTech
     "RTThrower-EjectorHatchRTRecipe", -- EjectorHatchRTTech
+	"RTThrower-FilterEjectorHatchRTRecipe", -- EjectorHatchRTTech (Added in Renai Transportation 1.3.0)
     "DirectorBouncePlateRecipie", -- RTSimonSays
     "SignalBouncePlateRecipie", -- SignalPlateTech
     "RTTrainRampRecipe", -- RTFlyingFreight

--- a/updates/compatibility/renai_transportation_config_changed.lua
+++ b/updates/compatibility/renai_transportation_config_changed.lua
@@ -1,0 +1,43 @@
+return function(ConfigurationChangedData)
+	-- TODO: Would probably be appropriate to move the following function to some utility function script for use by future mod config_changed scripts - Wrothmonk
+	-- Converts a mod's version number string to a table consisting of {major, minor, sub} version numbers, and allows comparison to other version number tables
+	local function mod_version_str_to_comparible(v_string)
+		-- Convert to list consisting of {major, minor, sub} version number strings
+		local result = {string.match(v_string, "(%d+)%.(%d+)%.(%d+)")}
+
+		-- convert to actual numerical values
+		for i = 1, 3, 1 do
+			result[i] = tonumber(result[i])
+		end
+
+		-- Implement comparison functions via metatable
+		setmetatable(result, {
+			__eq = function(a, b) return a[1] == b[1] and a[2] == b[2] and a[3] == b[3] end,
+			__lt = function(a, b) return
+				a[1] < b[1] -- Major version is less
+				or (a[1] == b[1] and -- Major version is the same and...
+					(a[2] < b[2] -- Minor version is less
+						or (a[2] == b[2] and a[3] < b[3]) -- or Minor version is the same and Sub version is less
+					)
+				)
+			end
+		})
+
+		return result
+	end
+
+	local mod_change = ConfigurationChangedData.mod_changes["RenaiTransportation"] -- version change info for Renai Transportation, if applicable
+
+	-- Renai Transportation has had a version update
+	if mod_change and mod_change.old_version and mod_change.new_version then
+		local old_version = mod_version_str_to_comparible(mod_change.old_version)
+		local new_version = mod_version_str_to_comparible(mod_change.new_version)
+		local filter_migration_version = mod_version_str_to_comparible("1.3.0") -- Version that added filter ejector hatches
+		if old_version < filter_migration_version and new_version >= filter_migration_version then -- Renai Transportation 1.3.0 migrations were just run on this save
+			-- Renai Transportation force enables the base filter ejector hatch recipe during 1.3.0 migrations, so we need to undo that
+			for each, force in pairs(game.forces) do
+				force.recipes["RTThrower-FilterEjectorHatchRTRecipe"].enabled = false
+			end
+		end
+	end
+end

--- a/updates/mod_config_changed_handling.lua
+++ b/updates/mod_config_changed_handling.lua
@@ -1,0 +1,15 @@
+-- Table of all on_config_changed handlers 
+local mod_config_changed_handlers = {
+	require("compatibility.renai_transportation_config_changed"),
+}
+
+local mod_config_changed = {
+	-- Runs all mod-specific on_configuration_changed handler functions 
+	run_handlers = function(ConfigurationChangedData)
+		for _, handler in ipairs(mod_config_changed_handlers) do
+			handler(ConfigurationChangedData)
+		end
+	end
+}
+
+return mod_config_changed


### PR DESCRIPTION
This adds support for the Filter Ejector Hatch added by Renai Transportation v1.3.0.

This also adds a system to allow compatibility scripts to be made specifically for responding to mod migration changes using the on_configuration_changed function, as that is sort of required to disable any recipes that are re-enabled by the migration code of a mod. The alternative would be to add a similar re-disabling of recipes to Ultracube's own migration scripts, but that would necessitate making each version of Ultracube support a defined version range for each individual compatible mod.

Maybe there's a more elegant solution I'm just not thinking of, so feel free to tweak the code of this pull request as you like. I specifically organized things so the first commit is all that's needed to handle creating the Ultracube version of the new recipe. So if you wanted to handle the issue caused by migration scripts completely differently, just apply the first commit and ignore/reverse the second.