### PR TITLE
Add Ultracube compatibility for LTN_Combinator_Modernized

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -15,6 +15,7 @@ require("updates.compatibility.inventory_sensor")
 require("updates.compatibility.jetpack")
 require("updates.compatibility.larger_lamps")
 require("updates.compatibility.ltn")
+require("updates.compatibility.ltn_combinator_modernized")
 require("updates.compatibility.nixie_tubes")
 require("updates.compatibility.pushbutton")
 require("updates.compatibility.quick_adjustable_inserters")
@@ -34,5 +35,5 @@ require("updates.disable_incompatible")
 require("updates.ultralocomotion")
 
 for _, t in pairs(data.raw.technology) do
-  t.enabled = false
+    t.enabled = false
 end

--- a/updates/compatibility/ltn_combinator_modernized.lua
+++ b/updates/compatibility/ltn_combinator_modernized.lua
@@ -1,0 +1,16 @@
+if mods["LTN_Combinator_Modernized"] then
+    local recipe = data.raw.recipe["ltn-combinator"]
+    recipe.category = "cube-fabricator-handcraft"
+    recipe.ingredients = {{"constant-combinator", 1}, {"cube-electronic-circuit", 1}}
+    recipe.enabled = false
+
+    data.raw.item["ltn-combinator"].subgroup = "cube-combinator-extra"
+    data.raw.item["ltn-combinator"].order = "cube-" .. data.raw.item["ltn-combinator"].order
+
+    table.insert(data.raw.technology["logistic-train-network"].effects, {
+        type = "unlock-recipe",
+        recipe = "ltn-combinator"
+    })
+
+    add_mystery_recipe(1, "ltn-combinator", "cube-electronic-circuit")
+end


### PR DESCRIPTION
Added compatibility with LTN_Combinator_Modernised.

## Testing

- Verified that `ltn-combinator` recipe appears correctly in-game.
- Tested crafting and technology unlocks to ensure compatibility.

## Related Issues

- N/A

## Additional Notes

Please review the changes and let me know if any adjustments are needed.