### PR TITLE
Fix a crash when Flow Control mod is present

### DIFF
--- a/updates/compatibility/flow_control.lua
+++ b/updates/compatibility/flow_control.lua
@@ -6,39 +6,39 @@ if mods["Flow Control"] then
   data:extend({
     {
       type = "recipe",
-      name = "cube-check-valve",
+      name = "cube-valves-one_way",
       ingredients = {
         {type = "item", name = "pipe", amount = 1},
         {type = "item", name = "cube-basic-matter-unit", amount = 2},
         {type = "item", name = "cube-basic-motor-unit", amount = 1},
       },
-      results = {{type = "item", name = "check-valve", amount = 1}},
+      results = {{type = "item", name = "valves-one_way", amount = 1}},
       energy_required = 1,
       category = "cube-fabricator-handcraft",
       enabled = false,
     },
     {
       type = "recipe",
-      name = "cube-overflow-valve",
+      name = "cube-valves-overflow",
       ingredients = {
         {type = "item", name = "pipe", amount = 1},
         {type = "item", name = "cube-electronic-circuit", amount = 1},
         {type = "item", name = "cube-basic-motor-unit", amount = 1},
       },
-      results = {{type = "item", name = "overflow-valve", amount = 1}},
+      results = {{type = "item", name = "valves-overflow", amount = 1}},
       energy_required = 1,
       category = "cube-fabricator-handcraft",
       enabled = false,
     },
     {
       type = "recipe",
-      name = "cube-underflow-valve",
+      name = "cube-valves-top_up",
       ingredients = {
         {type = "item", name = "pipe", amount = 1},
         {type = "item", name = "cube-electronic-circuit", amount = 1},
         {type = "item", name = "cube-basic-motor-unit", amount = 1},
       },
-      results = {{type = "item", name = "underflow-valve", amount = 1}},
+      results = {{type = "item", name = "valves-top_up", amount = 1}},
       energy_required = 1,
       category = "cube-fabricator-handcraft",
       enabled = false,
@@ -47,11 +47,11 @@ if mods["Flow Control"] then
       type = "technology",
       name = "flow_control_valves_tech",
       icon_size = 256,
-      icon = "__Flow Control__/graphics/technology/flow_control_valves_tech.png",
+      icon = "__Flow Control__/graphics/icon/pipe-straight.png",
       effects = {
-        {type = "unlock-recipe", recipe = "cube-check-valve"},
-        {type = "unlock-recipe", recipe = "cube-overflow-valve"},
-        {type = "unlock-recipe", recipe = "cube-underflow-valve"},
+        {type = "unlock-recipe", recipe = "cube-valves-one_way"},
+        {type = "unlock-recipe", recipe = "cube-valves-overflow"},
+        {type = "unlock-recipe", recipe = "cube-valves-top_up"},
       },
       prerequisites = {
         "cube-fundamental-comprehension-card",
@@ -61,9 +61,9 @@ if mods["Flow Control"] then
       order = "x-0-1",
     },
   })
-  data.raw.item["check-valve"].order = "cube-" .. data.raw.item["check-valve"].order
-  data.raw.item["overflow-valve"].order = "cube-" .. data.raw.item["overflow-valve"].order
-  data.raw.item["underflow-valve"].order = "cube-" .. data.raw.item["underflow-valve"].order
+  data.raw.item["valves-one_way"].order = "cube-" .. data.raw.item["valves-one_way"].order
+  data.raw.item["valves-overflow"].order = "cube-" .. data.raw.item["valves-overflow"].order
+  data.raw.item["valves-top_up"].order = "cube-" .. data.raw.item["valves-top_up"].order
   data.raw.recipe["pipe-elbow"].order = "cube-" .. data.raw.item["pipe-elbow"].order
   data.raw.recipe["pipe-junction"].order = "cube-" .. data.raw.item["pipe-junction"].order
   data.raw.recipe["pipe-straight"].order = "cube-" .. data.raw.item["pipe-straight"].order
@@ -71,7 +71,7 @@ if mods["Flow Control"] then
   add_mystery_recipe(1, "pipe-elbow", "pipe")
   add_mystery_recipe(1, "pipe-junction", "pipe")
   add_mystery_recipe(1, "pipe-straight", "pipe")
-  add_mystery_recipe(1, "check-valve", "pipe")
-  add_mystery_recipe(1, "overflow-valve", "pipe")
-  add_mystery_recipe(1, "underflow-valve", "pipe")
+  add_mystery_recipe(1, "valves-one_way", "pipe")
+  add_mystery_recipe(1, "valves-overflow", "pipe")
+  add_mystery_recipe(1, "valves-top_up", "pipe")
 end


### PR DESCRIPTION
This changes are intended to fix a crash when loading the game when Flow Control mod is present.

Latest version of the Flow Control mod is relying on Valves mod and some keys no longer match.
[https://github.com/snouz/Flow-Control/blob/main/migrations/0001-2.0.json](https://github.com/snouz/Flow-Control/blob/main/migrations/0001-2.0.json)

There are still issues like missing translations, but at least it is playable again.