### PR TITLE
Give purple belts the belt_reader sprite

### DIFF
--- a/prototypes/entities/belts.lua
+++ b/prototypes/entities/belts.lua
@@ -9,6 +9,8 @@ local v4_transport_belt_animation_set = {
     direction_count = 20,
   },
 
+  belt_reader = belt_reader_gfx.belt_reader,
+  
   east_index = 1,
   west_index = 2,
   north_index = 3,


### PR DESCRIPTION
The functionality was already there, inherited from base belts, just missing the belt_reader sprite.
![image](https://github.com/user-attachments/assets/b6b515b3-1728-4089-bc08-ca459f843c70)
