### PR TITLE
Perform an auto-save the first time the player starts crafting the Helvetica Scenario

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -6,7 +6,7 @@ do
 end
 
 local activation = require("__Ultracube__/scripts/activation")
-local cube_fx = require("__Ultracube__/scripts/autosave")
+local autosave = require("__Ultracube__/scripts/autosave")
 local cube_fx = require("__Ultracube__/scripts/cube_fx")
 local cube_search = require("__Ultracube__/scripts/cube_search")
 local cube_management = require("__Ultracube__/scripts/cube_management")

--- a/control.lua
+++ b/control.lua
@@ -6,6 +6,7 @@ do
 end
 
 local activation = require("__Ultracube__/scripts/activation")
+local cube_fx = require("__Ultracube__/scripts/autosave")
 local cube_fx = require("__Ultracube__/scripts/cube_fx")
 local cube_search = require("__Ultracube__/scripts/cube_search")
 local cube_management = require("__Ultracube__/scripts/cube_management")
@@ -331,6 +332,7 @@ script.on_event(defines.events.on_tick,
     transition.tick(tick)
     linked_entities.tick(tick)
     cubecam.tick(tick)
+    autosave.on_tick(tick)
   end)
 
 -- Custom input events.

--- a/migrations/0.6.6_autosave.lua
+++ b/migrations/0.6.6_autosave.lua
@@ -1,3 +1,7 @@
+-- If a ziggurat exists in the game world already, and has already finished crafting at least one recipe,
+-- the player's cube is already either softlocked to be broken, or they've managed to successfully recover
+-- it, so there's no need to autosave in worlds which meet this condition
+
 ziggurat = game.surfaces[1].find_entities_filtered{name = "cube-forbidden-ziggurat"}[1]
 
 if ziggurat and ziggurat.valid and ziggurat.products_finished >= 1 then

--- a/migrations/0.6.6_autosave.lua
+++ b/migrations/0.6.6_autosave.lua
@@ -1,0 +1,5 @@
+ziggurat = game.surfaces[1].find_entities_filtered{name = "cube-forbidden-ziggurat"}[1]
+
+if ziggurat and ziggurat.valid and ziggurat.products_finished >= 1 then
+    storage.has_autosaved_helvetica = true
+end

--- a/scripts/autosave.lua
+++ b/scripts/autosave.lua
@@ -1,0 +1,26 @@
+local cube_search = require("__Ultracube__/scripts/cube_search")
+
+local autosave = {}
+
+-- Perform an autosave the first time a Forbidden Ziggurat starts crafting
+function helvetica_scenario_autosave()
+    if storage.has_autosaved_helvetica then return end
+
+    local size, results = cube_search.update(tick)
+
+    if size != 1 then return end
+    if size < 1 then return end
+
+    local result = results[i]
+    local entity = result.entity
+    if entity and entity.valid then
+        if entity.name == "cube-forbidden-ziggurat" and entity.crafting_progress > 0 then
+            game.auto_save("first-helvetica-scenario")
+            storage.has_autosaved_helvetica = true
+        end
+    end
+end
+
+function autosave.on_tick()
+    helvetica_scenario_autosave()
+end

--- a/scripts/autosave.lua
+++ b/scripts/autosave.lua
@@ -21,6 +21,6 @@ function helvetica_scenario_autosave()
     end
 end
 
-function autosave.on_tick()
+function autosave.on_tick(_tick)
     helvetica_scenario_autosave()
 end

--- a/scripts/autosave.lua
+++ b/scripts/autosave.lua
@@ -3,15 +3,14 @@ local cube_search = require("__Ultracube__/scripts/cube_search")
 local autosave = {}
 
 -- Perform an autosave the first time a Forbidden Ziggurat starts crafting
-function helvetica_scenario_autosave()
+function helvetica_scenario_autosave(tick)
     if storage.has_autosaved_helvetica then return end
 
     local size, results = cube_search.update(tick)
 
-    if size != 1 then return end
-    if size < 1 then return end
+    if size ~= 1 then return end
 
-    local result = results[i]
+    local result = results[1]
     local entity = result.entity
     if entity and entity.valid then
         if entity.name == "cube-forbidden-ziggurat" and entity.crafting_progress > 0 then
@@ -21,6 +20,8 @@ function helvetica_scenario_autosave()
     end
 end
 
-function autosave.on_tick(_tick)
-    helvetica_scenario_autosave()
+function autosave.on_tick(tick)
+    helvetica_scenario_autosave(tick)
 end
+
+return autosave


### PR DESCRIPTION
This patch makes the game create an autosave the first time a Forbidden Ziggurat starts crafting, to help mitigate any potential soft-lock which might happen if the player doesn't have the necessary resources to reassemble the cube. It won't perform the save in a save-file which has already performed the Helvetica Scenario recipe, and won't perform the save after the first time.