### PR TITLE
Obliterate rocket capacity

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -9,11 +9,16 @@ end
 data.raw["electric-pole"]["cube-local-turbine-source"].maximum_wire_distance = 0
 data.raw["electric-pole"]["cube-local-turbine-transmitter"].maximum_wire_distance = 0
 
+local constants = data.raw["utility-constants"].default
+constants.default_item_weight=0
+constants.rocket_lift_weight=0
+
 -- Make sure items can be sent automatically in the teleporter.
 for type, _ in pairs(defines.prototypes.item) do
   for _, item in pairs(data.raw[type] or {}) do
     --item.rocket_launch_products = {{type = "item", name = "space-science-pack", amount = 0}}
     item.send_to_orbit_mode = "automated"
+    item.ingredient_to_weight_coefficient = 0
   end
 end
 data.raw.item["cube-residual-tendrils"].rocket_launch_products = {{type = "item", name = "cube-residual-tendrils", amount = 100}}

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -42,7 +42,7 @@ for t, _ in pairs(defines.prototypes.item) do
   if data.raw[t] then
     for _, v in pairs(data.raw[t]) do
       v.hidden_in_factoriopedia = true
-      v.weight = (1000 * 1000) / v.stack_size
+      v.weight = 0
     end
   end
 end


### PR DESCRIPTION
This removes the tooltips from the GUI. Teleporters can send one stack of any item.