### PR TITLE
Fix Lighted Electric Poles compatibility

### DIFF
--- a/updates/compatibility/lighted_poles_plus.lua
+++ b/updates/compatibility/lighted_poles_plus.lua
@@ -1,4 +1,4 @@
-if mods["LightedPolesPlus"] then
+if mods["Lighted-Poles-Plus"] then
   -- Medium pole is special because it starts unlocked.
   if data.raw.recipe["lighted-medium-electric-pole"] then
     local technology = data.raw.technology["cube-optics"]


### PR DESCRIPTION
I noticed that the linked `Lighted Electric Poles+` mod doesn't work with version 2.x, and the version that does work with 2.x (https://mods.factorio.com/mod/Lighted-Poles-Plus) isn't compatible with Ultracube because the name of the mod changed slightly.  Updating `lighted_poles_plus.lua` resolved the issue for me.