### PR TITLE
"Safe Waterfill" is now updated for 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The following mods have been specifically adapted to work with Ultracube:
 | [Renai Transportation](https://mods.factorio.com/mod/RenaiTransportation) | |
 | [Railway Motor Car](https://mods.factorio.com/mod/railway-motor-car) | |
 | [Recursive Blueprints](https://mods.factorio.com/mod/recursive-blueprints) | [Recursive Blueprints+](https://mods.factorio.com/mod/rec-blue-plus) is also supported. Note: be careful, it's currently possible to destroy the cube by overwriting a machine's recipe with a blueprint deployer when it holds the cube in some cases |
-| [Safe Waterfill](https://mods.factorio.com/mod/safefill) | not yet updated for 2.0 as of last check |
+| [Safe Waterfill](https://mods.factorio.com/mod/safefill) | |
 | [Textplates](https://mods.factorio.com/mod/textplates) | |
 | [Tiny Assemblers](https://mods.factorio.com/mod/tiny-assemblers) | |
 | [Tiny Storage Tanks](https://mods.factorio.com/mod/est-tiny-storage-tank) | |


### PR DESCRIPTION
Safe Waterfill has now been updated for 2.0, so the reference that it does not has been removed. 